### PR TITLE
#7 Create ConfirmationDialog common component

### DIFF
--- a/src/components/shared/ConfirmationDialog.tsx
+++ b/src/components/shared/ConfirmationDialog.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogContentText from '@material-ui/core/DialogContentText'
+import DialogTitle from '@material-ui/core/DialogTitle'
+
+export type ConfirmationDialogRef = HTMLDialogElement
+export interface ConfirmationDialogProps {
+  isOpen: boolean
+  handleConfirm: () => void
+  handleCancel: () => void
+  title: string
+  content: string
+  confirmButtonLabel: string
+  cancelButtonLabel: string
+}
+
+const ConfirmationDialog = ({
+  isOpen,
+  handleConfirm,
+  handleCancel,
+  title,
+  content,
+  confirmButtonLabel,
+  cancelButtonLabel,
+}: ConfirmationDialogProps) => (
+  <Dialog
+    open={isOpen}
+    onClose={handleCancel}
+    aria-labelledby="alert-dialog-title"
+    aria-describedby="alert-dialog-description">
+    <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+    <DialogContent>
+      <DialogContentText id="alert-dialog-description">{content}</DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={handleConfirm} color="primary">
+        {confirmButtonLabel}
+      </Button>
+      <Button onClick={handleCancel} color="secondary">
+        {cancelButtonLabel}
+      </Button>
+    </DialogActions>
+  </Dialog>
+)
+
+export default ConfirmationDialog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Create confirmation dialog common component

Issue: https://github.com/daritelska-platforma/frontend/issues/7

A sample confirmation dialog. Additional styles, props and tests can be added further when we have more clarity about the usage.

![Screenshot (414)](https://user-images.githubusercontent.com/19424332/105624198-163d1b80-5e20-11eb-8a55-c621fab67ce4.png)
