### PR TITLE
Trigger warning when using any as type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 1,
     'react/react-in-jsx-scope': 'off',
   },
 }

--- a/src/common/form/validation.ts
+++ b/src/common/form/validation.ts
@@ -1,8 +1,9 @@
 import { setLocale } from 'yup'
+import { TOptions } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 export const translateError = (
-  field: (string | undefined) | { key: string; values?: any },
+  field: (string | undefined) | { key: string; values?: TOptions },
 ): string | undefined => {
   const { t } = useTranslation()
   if (!field) {

--- a/src/pages/api/timeout.tsx
+++ b/src/pages/api/timeout.tsx
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export type TimeoutResponse = {
-  input: any
+  input: unknown
   success: boolean
 }
 
-function delay(timeout: number, val?: any) {
+function delay(timeout: number, val?: unknown) {
   return new Promise(function (resolve) {
     setTimeout(function () {
       resolve(val)

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,7 +5,7 @@ import { routes } from 'common/routes'
 import LoginPage from 'components/auth/login/LoginPage'
 import { serverSideTranslations } from 'common/useNextLocale'
 
-type UnboxPromise<T extends Promise<any>> = T extends Promise<infer U> ? U : never
+type UnboxPromise<T extends Promise<unknown>> = T extends Promise<infer U> ? U : never
 
 export type LoginPageProps = { providers: UnboxPromise<ReturnType<typeof providers>> }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Provide link to ora.pm task if any -->

Type `any` is provides the ability skip strict type checks and may lead to problems in debugging

This PR enables a warning when we use `any` in the codebase while we're at the beginning of the journey and the codebase is small.

However sometimes is more convenient to use `unknown` instead of `any`.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md


