### PR TITLE
Improve TeamPie on phone portrait mode

### DIFF
--- a/src/components/chart/TeamPie.tsx
+++ b/src/components/chart/TeamPie.tsx
@@ -5,7 +5,7 @@ import { teamPieData, TeamPieData } from 'components/chart/pieData'
 
 const styles = {
   height: '380px',
-  width: '100%',
+  width: '99%',
   paddingTop: '20px',
 }
 
@@ -19,11 +19,11 @@ const TeamPie = () => {
     <div style={styles}>
       <ResponsivePie
         data={teamPieData}
-        margin={{ top: 30, right: 0, bottom: 30, left: 0 }}
+        margin={{ top: 30, right: 100, bottom: 30, left: 100 }}
         innerRadius={0.4}
         padAngle={0.7}
         radialLabelsLinkDiagonalLength={20}
-        radialLabelsLinkHorizontalLength={20}
+        radialLabelsLinkHorizontalLength={5}
         sliceLabelsRadiusOffset={0.65}
         colors={{ scheme: 'set2' }}
         radialLabel="label"


### PR DESCRIPTION
Still not perfect but at least if you turn from landscape mode to portrait, the pie renders back as before.
And now you can see most of the labels. On the others screens there is no change, they look fine as before.

![Screenshot (679)](https://user-images.githubusercontent.com/19424332/109269411-bd8ce400-780c-11eb-81cf-f98449bc0984.png)