### PR TITLE
Added markup according to seo instructions. 

### DIFF
--- a/public/locales/bg/index.json
+++ b/public/locales/bg/index.json
@@ -45,7 +45,7 @@
   "problems-to-solve-section": {
     "heading": "Какъв е проблемът, който се опитваме да решим:",
     "high-commissions": "Високи комисионни",
-    "low-transparency": "Ниска (липса на) прозрачност",
-    "timeliness": "Навременност на даренията"
+    "low-transparency": "Липса на прозрачност",
+    "timeliness": "Закъснели дарения"
   }
 }

--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -45,7 +45,7 @@
   "problems-to-solve-section": {
     "heading": "What is the problem that we are trying to solve:",
     "high-commissions": "High commissions",
-    "low-transparency": "Low (lack of) transparency",
+    "low-transparency": "Lack of transparency",
     "timeliness": "Donation timeliness"
   }
 }

--- a/src/components/index/IndexPage.tsx
+++ b/src/components/index/IndexPage.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@material-ui/core'
-import { useTranslation } from 'react-i18next'
 
 import Layout from 'components/layout/Layout'
+
 import Jumbotron from './sections/Jumbotron'
 import ActivitySection from './sections/ActivitySection'
 import TeamSection from './sections/TeamSection'
@@ -10,10 +10,8 @@ import SupportUsSection from './sections/SupportUsSection'
 import ProblemsToSolveSection from './sections/ProblemsToSolveSection'
 
 export default function Index() {
-  const { t } = useTranslation()
-
   return (
-    <Layout maxWidth={false} disableOffset>
+    <Layout maxWidth={false} disableOffset disableGutters>
       <Jumbotron />
       <Container maxWidth="md">
         <ActivitySection />

--- a/src/components/index/sections/ActivitySection.tsx
+++ b/src/components/index/sections/ActivitySection.tsx
@@ -21,7 +21,7 @@ export default function ActivitySection() {
 
   return (
     <Grid container direction="column" component="section" className={classes.container}>
-      <Typography variant="h5" className={classes.heading}>
+      <Typography variant="h5" component="h2" className={classes.heading}>
         {t('index:activity-section.heading')}
       </Typography>
       <Grid item>

--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -1,7 +1,7 @@
 import Typewriter from 'typewriter-effect'
 import { useTranslation } from 'react-i18next'
 
-import { Grid, Typography } from '@material-ui/core'
+import { Box, Grid, Typography } from '@material-ui/core'
 import { makeStyles, createStyles } from '@material-ui/core/styles'
 
 import { routes } from 'common/routes'
@@ -10,8 +10,8 @@ import LinkButton from 'components/common/LinkButton'
 const useStyles = makeStyles((theme) =>
   createStyles({
     container: {
-      paddingTop: theme.spacing(30),
-      marginBottom: theme.spacing(12),
+      paddingTop: theme.spacing(15),
+      marginBottom: theme.spacing(15),
       textAlign: 'center',
       backgroundImage: 'url(img/header-image.png)',
       backgroundPosition: 'center',
@@ -21,13 +21,19 @@ const useStyles = makeStyles((theme) =>
     },
     title: {
       color: theme.palette.common.white,
+      textShadow: '1px 2px rgba(0, 0, 0, 0.35)',
+    },
+    subTitle: {
+      marginTop: theme.spacing(3),
     },
     typewriter: {
       marginBottom: theme.spacing(5),
+      textShadow: '1px 2px rgba(0, 0, 0, 0.35)',
     },
     podkrepiButton: {
       color: theme.palette.common.white,
       borderColor: theme.palette.common.white,
+      padding: theme.spacing(2, 4),
     },
   }),
 )
@@ -41,9 +47,11 @@ export default function Index() {
       <Grid item className={classes.title}>
         <Typography gutterBottom variant="h1">
           {t('index:title')}
+          <Typography variant="h5" component="p" className={classes.subTitle}>
+            {t('index:jumbotron.heading')}
+          </Typography>
         </Typography>
-        <Typography variant="h5">{t('index:jumbotron.heading')}</Typography>
-        <Typography variant="h4" className={classes.typewriter}>
+        <Typography variant="h4" component="h4" className={classes.typewriter}>
           <Typewriter
             onInit={(typewriter) => {
               typewriter
@@ -72,9 +80,11 @@ export default function Index() {
         </Typography>
       </Grid>
       <Grid item>
-        <LinkButton href={routes.support} variant="outlined" className={classes.podkrepiButton}>
-          {t('index:jumbotron.support-us-button')}
-        </LinkButton>
+        <Box mt={25}>
+          <LinkButton href={routes.support} variant="outlined" className={classes.podkrepiButton}>
+            {t('index:jumbotron.support-us-button')}
+          </LinkButton>
+        </Box>
       </Grid>
     </Grid>
   )

--- a/src/components/index/sections/ProblemsToSolveSection.tsx
+++ b/src/components/index/sections/ProblemsToSolveSection.tsx
@@ -9,19 +9,18 @@ import TimelinessIcon from '../icons/problems-to-solve-icons/TimelinessIcon'
 const useStyles = makeStyles((theme) =>
   createStyles({
     heading: {
-      margin: 'auto',
-      marginBottom: theme.spacing(5),
       textAlign: 'center',
-      maxWidth: '50%',
       color: theme.palette.primary.dark,
+      padding: theme.spacing(0, 4),
     },
     problem: {
       display: 'flex',
+      justifyContent: 'center',
       alignItems: 'center',
-      flexBasis: '23%',
     },
     icon: {
       fontSize: theme.spacing(10),
+      padding: theme.spacing(1),
       marginRight: theme.spacing(1),
     },
     problemLabel: {
@@ -35,28 +34,36 @@ export default function SupportUsSection() {
   const { t } = useTranslation()
 
   return (
-    <Grid container component="section">
-      <Typography variant="h5" className={classes.heading}>
-        {t('index:problems-to-solve-section.heading')}
-      </Typography>
-      <Grid container direction="row" justify="space-between" alignItems="center">
-        <Grid item className={classes.problem}>
-          <CommissionsIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.problemLabel}>
-            {t('index:problems-to-solve-section.high-commissions')}
-          </Typography>
+    <Grid container component="section" justify="center" spacing={5}>
+      <Grid item>
+        <Typography variant="h5" component="h2" className={classes.heading}>
+          {t('index:problems-to-solve-section.heading')}
+        </Typography>
+      </Grid>
+      <Grid item container>
+        <Grid item xs={12} sm={4}>
+          <div className={classes.problem}>
+            <CommissionsIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.problemLabel}>
+              {t('index:problems-to-solve-section.high-commissions')}
+            </Typography>
+          </div>
         </Grid>
-        <Grid item className={classes.problem}>
-          <TransparencyIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.problemLabel}>
-            {t('index:problems-to-solve-section.low-transparency')}
-          </Typography>
+        <Grid item xs={12} sm={4}>
+          <div className={classes.problem}>
+            <TransparencyIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.problemLabel}>
+              {t('index:problems-to-solve-section.low-transparency')}
+            </Typography>
+          </div>
         </Grid>
-        <Grid item className={classes.problem}>
-          <TimelinessIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.problemLabel}>
-            {t('index:problems-to-solve-section.timeliness')}
-          </Typography>
+        <Grid item xs={12} sm={4}>
+          <div className={classes.problem}>
+            <TimelinessIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.problemLabel}>
+              {t('index:problems-to-solve-section.timeliness')}
+            </Typography>
+          </div>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/index/sections/SupportUsSection.tsx
+++ b/src/components/index/sections/SupportUsSection.tsx
@@ -18,15 +18,12 @@ const useStyles = makeStyles((theme) =>
       textAlign: 'center',
     },
     supportOptionsWrapper: {
-      paddingLeft: theme.spacing(8),
-      paddingRight: theme.spacing(8),
+      padding: theme.spacing(2),
     },
     supportOption: {
-      display: 'flex',
       border: '1px solid #284E84',
-      borderRadius: theme.spacing(1),
-      width: '180px',
-      height: '200px',
+      padding: theme.spacing(2),
+      borderRadius: 3,
       '&:hover': {
         backgroundColor: theme.palette.primary.dark,
         cursor: 'pointer',
@@ -55,57 +52,41 @@ export default function SupportUsSection() {
       justify="center"
       component="section"
       className={classes.container}>
-      <Typography variant="h5" className={classes.heading}>
+      <Typography variant="h5" component="h2" className={classes.heading}>
         {t('index:support-us-section.heading')}
       </Typography>
-      <Grid
-        container
-        direction="row"
-        justify="space-between"
-        className={classes.supportOptionsWrapper}>
-        <Grid
-          container
-          direction="column"
-          alignItems="center"
-          justify="center"
-          className={classes.supportOption}>
-          <FinancesIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.supportOptionLabel}>
-            {t('index:support-us-section.financial-support')}
-          </Typography>
+      <Grid container spacing={2} className={classes.supportOptionsWrapper}>
+        <Grid item xs={12} sm={6} md={3}>
+          <div className={classes.supportOption}>
+            <FinancesIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.supportOptionLabel}>
+              {t('index:support-us-section.financial-support')}
+            </Typography>
+          </div>
         </Grid>
-        <Grid
-          container
-          direction="column"
-          alignItems="center"
-          justify="center"
-          className={classes.supportOption}>
-          <LabourIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.supportOptionLabel}>
-            {t('index:support-us-section.labour-support')}
-          </Typography>
+        <Grid item xs={12} sm={6} md={3}>
+          <div className={classes.supportOption}>
+            <LabourIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.supportOptionLabel}>
+              {t('index:support-us-section.labour-support')}
+            </Typography>
+          </div>
         </Grid>
-        <Grid
-          container
-          direction="column"
-          alignItems="center"
-          justify="center"
-          className={classes.supportOption}>
-          <MediaIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.supportOptionLabel}>
-            {t('index:support-us-section.media-support')}
-          </Typography>
+        <Grid item xs={12} sm={6} md={3}>
+          <div className={classes.supportOption}>
+            <MediaIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.supportOptionLabel}>
+              {t('index:support-us-section.media-support')}
+            </Typography>
+          </div>
         </Grid>
-        <Grid
-          container
-          direction="column"
-          alignItems="center"
-          justify="center"
-          className={classes.supportOption}>
-          <PartnershipIcon className={classes.icon} />
-          <Typography variant="body2" className={classes.supportOptionLabel}>
-            {t('index:support-us-section.become-a-partner')}
-          </Typography>
+        <Grid item xs={12} sm={6} md={3}>
+          <div className={classes.supportOption}>
+            <PartnershipIcon className={classes.icon} />
+            <Typography variant="body2" className={classes.supportOptionLabel}>
+              {t('index:support-us-section.become-a-partner')}
+            </Typography>
+          </div>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/index/sections/TeamChartSection.tsx
+++ b/src/components/index/sections/TeamChartSection.tsx
@@ -19,15 +19,17 @@ const TeamChartSection = () => {
 
   return (
     <Box component="section" mb={10} textAlign="center">
-      <Grid container direction="column" alignItems="center" justify="center">
+      <Grid container direction="column" justify="center" spacing={3}>
         <Grid item>
-          <Typography variant="h5" paragraph className={classes.heading}>
+          <Typography variant="h5" component="h2" className={classes.heading}>
             {t('index:team-chart-section.heading')}
           </Typography>
-          <Typography variant="subtitle1" paragraph>
-            {t('index:team-chart-section.content')}
-          </Typography>
-          <TeamPie />
+          <Typography variant="body2">{t('index:team-chart-section.content')}</Typography>
+        </Grid>
+        <Grid item>
+          <Box textAlign="center" overflow="hidden">
+            <TeamPie />
+          </Box>
         </Grid>
       </Grid>
     </Box>

--- a/src/components/index/sections/TeamSection.tsx
+++ b/src/components/index/sections/TeamSection.tsx
@@ -27,7 +27,7 @@ export default function TeamSection() {
       justify="center"
       component="section"
       className={classes.container}>
-      <Typography variant="h5" className={classes.heading}>
+      <Typography variant="h5" component="h2" className={classes.heading}>
         {t('index:team-section.heading')}
       </Typography>
       <Grid item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

- SEO tips by Ivelin Todorov
- Made some `h5` headings keep their style but be `h2` underneath 
- Responsiveness for couple sections on the homepage
- Made layout without gutters so the image goes full width
- Improved box sizing for activities


## Screenshots:

Before|After
---|---
![image](https://user-images.githubusercontent.com/893608/109422651-1d3de780-79e5-11eb-99b3-ec68599b6790.png)|![image](https://user-images.githubusercontent.com/893608/109422663-32b31180-79e5-11eb-927e-5d528158ccf5.png)
![image](https://user-images.githubusercontent.com/893608/109422689-49596880-79e5-11eb-8891-6b04d2481dae.png)|![image](https://user-images.githubusercontent.com/893608/109422707-668e3700-79e5-11eb-9116-77e0ca1bf0fc.png)


