### PR TITLE
added: skaffold configuration to enable native kubernetes developmen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 #############
 
 COMPOSE_PROJECT_NAME=podkrepi
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 NODE_ENV=development # development, production
 TARGET_ENV=development # development, production
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+services:
+  frontend:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+      target: ${TARGET_ENV}
+      args:
+        NODE_ENV: ${NODE_ENV}
+    ports:
+      - '${APP_PORT}:3040'
+    volumes:
+      # Local:Container mounting points
+      - ./src:/app/src
+      - ./public:/app/public
+      - ./node_modules:/app/node_modules
+      - ./.next:/app/.next
+
+networks:
+  frontend-net:
+    driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  app:
+  frontend:
     image: ghcr.io/daritelska-platforma/frontend/web:${DEPLOY_TAG}
     container_name: app-frontend-prod
     restart: always

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  app:
+  frontend:
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-version: '3.8'
+version: '3.7'
 services:
-  app:
+  frontend:
     container_name: ${COMPOSE_PROJECT_NAME?}-frontend
 
     build:
@@ -9,16 +9,16 @@ services:
       target: ${TARGET_ENV}
       args:
         NODE_ENV: ${NODE_ENV}
-
+    image: ${COMPOSE_PROJECT_NAME?}-frontend
     ports:
       - '${APP_PORT}:3040'
 
-    volumes:
-      # Local:Container mounting points
-      - ./src:/app/src
-      - ./public:/app/public
-      - /app/node_modules
-      - /app/.next
+    # volumes:
+    #   # Local:Container mounting points
+    #   - ./src:/app/src
+    #   - ./public:/app/public
+    #   - ./node_modules:/app/node_modules
+    #   - ./.next:/app/.next
 
     environment:
       API_URL: ${API_URL}
@@ -28,8 +28,8 @@ services:
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
 
     networks:
-      - net-frontend
+      - frontend-net
 
 networks:
-  net-frontend:
+  frontend-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,8 @@
 version: '3.7'
 services:
   frontend:
-    container_name: ${COMPOSE_PROJECT_NAME?}-frontend
-
-    build:
-      context: ./
-      dockerfile: ./Dockerfile
-      target: ${TARGET_ENV}
-      args:
-        NODE_ENV: ${NODE_ENV}
     image: ${COMPOSE_PROJECT_NAME?}-frontend
-    ports:
-      - '${APP_PORT}:3040'
-
-    # volumes:
-    #   # Local:Container mounting points
-    #   - ./src:/app/src
-    #   - ./public:/app/public
-    #   - ./node_modules:/app/node_modules
-    #   - ./.next:/app/.next
-
+    container_name: ${COMPOSE_PROJECT_NAME?}-frontend
     environment:
       API_URL: ${API_URL}
       NEXTAUTH_URL: ${NEXTAUTH_URL}

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -38,9 +38,11 @@ skaffold delete
 
 ### Connecting to CockroachDB
 
+- directly from the shell
 ```shell
 psql -h localhost -p 26257 -U root
 ```
+- from the code - [see CockroachDB code specific client drivers](https://www.cockroachlabs.com/docs/v20.2/install-client-drivers?filters=c-sharp)
 
 ## Cleanup
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,39 @@
+# Using skaffold for Native Kubernetes development
+If you want your code to be dynamically deployed to kubernetes
+
+## Prerequisites
+* Install [minikube](https://minikube.sigs.k8s.io/docs/start/) for Linux or [Docker Desktop](https://www.docker.com/products/docker-desktop) for Win or Mac
+* Install [skaffold](https://skaffold.dev/docs/install/)
+
+## Quickstart
+Just run this directly int the code folder. It will build the image, publish to local docker registry and deploy to Kubernetes. Then will start listening for changes in your workfolder and deploy automatically the new version to Kubernetes
+
+    skaffold dev --port-forward=true
+
+to see what was deployed use:
+
+    kubectl get pods --namespace podkrepi-dev
+
+## Stopping the listener
+* when you press Ctrl+C it will clear the deployment from kubernetes
+* if you don't wait the cleanup to finish some resources could remain, to clean just run:
+
+        skaffold delete
+
+## Things to know about Cockroachdb install
+* cockroachdb is installed in singlenode mode, without passwords to ease development
+* cockroachdb is recreated each time, if you don't want recreation, comment the manifest line in skaffold.yaml
+* portforwarding for cockroachdb won't work from the first run because it is slow to start. Just Ctrl+C and run skaffold dev again.
+
+## Cleanup
+* skaffold will create a lot of temporary images in docker, to clean everything:
+
+      docker system prune 
+      
+   or start skaffold like this: 
+      
+      skaffold dev --no-prune=false --cache-artifacts=false --no-prune-children=false --port-forward=true
+
+## How to configure from ground zero
+
+      docker-compose -f ./docker-compose.yml --env-file=.env.example config > docker-compose-resolved.tmp && skaffold init --compose-file docker-compose-resolved.tmp

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,39 +1,58 @@
 # Using skaffold for Native Kubernetes development
+
 If you want your code to be dynamically deployed to kubernetes
 
 ## Prerequisites
-* Install [minikube](https://minikube.sigs.k8s.io/docs/start/) for Linux or [Docker Desktop](https://www.docker.com/products/docker-desktop) for Win or Mac
-* Install [skaffold](https://skaffold.dev/docs/install/)
+
+- Install [minikube](https://minikube.sigs.k8s.io/docs/start/) for Linux or [Docker Desktop](https://www.docker.com/products/docker-desktop) for Win or Mac
+- Install [skaffold](https://skaffold.dev/docs/install/)
 
 ## Quickstart
+
 Just run this directly int the code folder. It will build the image, publish to local docker registry and deploy to Kubernetes. Then will start listening for changes in your workfolder and deploy automatically the new version to Kubernetes
 
-    skaffold dev --port-forward=true
+```shell
+skaffold dev --port-forward=true
+```
 
 to see what was deployed use:
 
-    kubectl get pods --namespace podkrepi-dev
+```shell
+kubectl get pods --namespace podkrepi-dev
+```
 
 ## Stopping the listener
-* when you press Ctrl+C it will clear the deployment from kubernetes
-* if you don't wait the cleanup to finish some resources could remain, to clean just run:
 
-        skaffold delete
+- when you press Ctrl+C it will clear the deployment from kubernetes
+- if you don't wait the cleanup to finish some resources could remain, to clean just run:
+
+```shell
+skaffold delete
+```
 
 ## Things to know about Cockroachdb install
-* cockroachdb is installed in singlenode mode, without passwords to ease development
-* cockroachdb is recreated each time, if you don't want recreation, comment the manifest line in skaffold.yaml
-* portforwarding for cockroachdb won't work from the first run because it is slow to start. Just Ctrl+C and run skaffold dev again.
+
+- cockroachdb is installed in singlenode mode, without passwords to ease development
+- cockroachdb is recreated each time, if you don't want recreation, comment the manifest line in skaffold.yaml
+- portforwarding for cockroachdb won't work from the first run because it is slow to start. Just Ctrl+C and run skaffold dev again.
 
 ## Cleanup
-* skaffold will create a lot of temporary images in docker, to clean everything:
 
-      docker system prune 
-      
-   or start skaffold like this: 
-      
-      skaffold dev --no-prune=false --cache-artifacts=false --no-prune-children=false --port-forward=true
+- skaffold will create a lot of temporary images in docker, to clean everything:
+
+```shell
+docker system prune
+```
+
+or start skaffold like this:
+
+```shell
+skaffold dev --no-prune=false --cache-artifacts=false --no-prune-children=false --port-forward=true
+```
 
 ## How to configure from ground zero
 
-      docker-compose -f ./docker-compose.yml --env-file=.env.example config > docker-compose-resolved.tmp && skaffold init --compose-file docker-compose-resolved.tmp
+```shell
+docker-compose -f ./docker-compose.yml --env-file=.env.example config > docker-compose-resolved.tmp \
+  && skaffold init --compose-file docker-compose-resolved.tmp
+```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -30,11 +30,17 @@ kubectl get pods --namespace podkrepi-dev
 skaffold delete
 ```
 
-## Things to know about Cockroachdb install
+## Things to know about CockroachDB install
 
 - cockroachdb is installed in singlenode mode, without passwords to ease development
 - cockroachdb is recreated each time, if you don't want recreation, comment the manifest line in skaffold.yaml
 - portforwarding for cockroachdb won't work from the first run because it is slow to start. Just Ctrl+C and run skaffold dev again.
+
+### Connecting to CockroachDB
+
+```shell
+psql -h localhost -p 26257 -U root
+```
 
 ## Cleanup
 
@@ -56,3 +62,5 @@ skaffold dev --no-prune=false --cache-artifacts=false --no-prune-children=false 
 docker-compose -f ./docker-compose.yml --env-file=.env.example config > docker-compose-resolved.tmp \
   && skaffold init --compose-file docker-compose-resolved.tmp
 ```
+
+It's important not to include `docker-compose.dev.yml` as it generates local mounting volumes that have no effect over kubernetes cluster. By default dev yaml is included in `.env.example` within `COMPOSE_FILE` var.

--- a/kubernetes/cockroachdb.yaml
+++ b/kubernetes/cockroachdb.yaml
@@ -1,0 +1,182 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
+  # traffic and the cli.
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  # The secondary port serves the UI as well as health and debug endpoints.
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8080"
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  - port: 8080
+    targetPort: 8080
+    name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    app: cockroachdb
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  maxUnavailable: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+  labels:
+    app.kubernetes.io/managed-by: skaffold
+    skaffold.dev/run-id: static
+spec:
+  serviceName: "cockroachdb"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cockroachdb
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - cockroachdb
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: cockroachdb
+        image: cockroachdb/cockroach:v20.2.5
+        imagePullPolicy: IfNotPresent
+        # TODO: Change these to appropriate values for the hardware that you're running. You can see
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
+        #   kubectl describe nodes
+        # Note that requests and limits should have identical values.
+        resources:
+          requests:
+            cpu: "1"
+            memory: "500Mi"
+          limits:
+            cpu: "1"
+            memory: "500Mi" 
+        ports:
+        - containerPort: 26257
+          name: grpc
+        - containerPort: 8080
+          name: http
+        livenessProbe:
+          httpGet:
+            path: "/health"
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: "/health?ready=1"
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 2
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+        env:
+        - name: COCKROACH_CHANNEL
+          value: kubernetes-insecure
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+              divisor: "1"
+        - name: MEMORY_LIMIT_MIB
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: "1Mi"
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - exec
+            /cockroach/cockroach
+            start-single-node
+            --logtostderr
+            --insecure
+            --advertise-host $(hostname -f)
+            --http-addr 0.0.0.0
+            --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB
+            --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 1Gi

--- a/kubernetes/frontend-deployment.yaml
+++ b/kubernetes/frontend-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose-resolved.tmp
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose-resolved.tmp
+        kompose.version: 1.22.0 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.network/frontend-net: "true"
+        io.kompose.service: frontend
+    spec:
+      containers:
+        - env:
+            - name: API_URL
+              value: https://api.dp.localhost/
+            - name: DISCORD_CLIENT_ID
+            - name: DISCORD_CLIENT_SECRET
+            - name: JWT_SECRET
+              value: '!Change__Me!'
+            - name: NEXTAUTH_URL
+              value: https://localhost:3040
+          image: podkrepi-frontend
+          name: podkrepi-frontend
+          ports:
+            - containerPort: 3040
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/kubernetes/frontend-net-networkpolicy.yaml
+++ b/kubernetes/frontend-net-networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  name: frontend-net
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              io.kompose.network/frontend-net: "true"
+  podSelector:
+    matchLabels:
+      io.kompose.network/frontend-net: "true"

--- a/kubernetes/frontend-service.yaml
+++ b/kubernetes/frontend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose-resolved.tmp
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  ports:
+    - name: "3040"
+      port: 3040
+      targetPort: 3040
+  selector:
+    io.kompose.service: frontend
+status:
+  loadBalancer: {}

--- a/kubernetes/podkrepi-dev-namespace.yaml
+++ b/kubernetes/podkrepi-dev-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podkrepi-dev

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,26 +4,26 @@ metadata:
   name: frontend
 build:
   artifacts:
-  - image: podkrepi-frontend
-    docker:
-      dockerfile: Dockerfile
+    - image: podkrepi-frontend
+      docker:
+        dockerfile: Dockerfile
+        target: production
 deploy:
   kubectl:
     manifests:
-    - kubernetes/podkrepi-dev-namespace.yaml
-    - kubernetes/frontend-deployment.yaml
-    - kubernetes/frontend-net-networkpolicy.yaml
-    - kubernetes/frontend-service.yaml
-    - kubernetes/cockroachdb.yaml
+      - kubernetes/podkrepi-dev-namespace.yaml
+      - kubernetes/frontend-deployment.yaml
+      - kubernetes/frontend-net-networkpolicy.yaml
+      - kubernetes/frontend-service.yaml
+      - kubernetes/cockroachdb.yaml
     defaultNamespace: podkrepi-dev
     # flags:
     #   global: # additional flags passed on every command.
     #   - --namespace=podkrepi-dev
 
 portForward:
-- resourceType: Service
-  resourceName: frontend
-  namespace: podkrepi-dev
-  port: 3040
-  localPort: 3040
-  
+  - resourceType: Service
+    resourceName: frontend
+    namespace: podkrepi-dev
+    port: 3040
+    localPort: 3040

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,14 +12,11 @@ deploy:
   kubectl:
     manifests:
       - kubernetes/podkrepi-dev-namespace.yaml
+      - kubernetes/cockroachdb.yaml
       - kubernetes/frontend-deployment.yaml
       - kubernetes/frontend-net-networkpolicy.yaml
       - kubernetes/frontend-service.yaml
-      - kubernetes/cockroachdb.yaml
     defaultNamespace: podkrepi-dev
-    # flags:
-    #   global: # additional flags passed on every command.
-    #   - --namespace=podkrepi-dev
 
 portForward:
   - resourceType: Service

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,29 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+metadata:
+  name: frontend
+build:
+  artifacts:
+  - image: podkrepi-frontend
+    docker:
+      dockerfile: Dockerfile
+deploy:
+  kubectl:
+    manifests:
+    - kubernetes/podkrepi-dev-namespace.yaml
+    - kubernetes/frontend-deployment.yaml
+    - kubernetes/frontend-net-networkpolicy.yaml
+    - kubernetes/frontend-service.yaml
+    - kubernetes/cockroachdb.yaml
+    defaultNamespace: podkrepi-dev
+    # flags:
+    #   global: # additional flags passed on every command.
+    #   - --namespace=podkrepi-dev
+
+portForward:
+- resourceType: Service
+  resourceName: frontend
+  namespace: podkrepi-dev
+  port: 3040
+  localPort: 3040
+  


### PR DESCRIPTION
added: skaffold configuration to enable native kubernetes development
added: cockroachdb as singlenode
updated: docker-compose.yml to allow running kompose which requires version 3.7

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context
The change introduces skaffold config which makes it easier to have local kubernetes environment for developing and testing in similar to production environment. See the readme.md in ./kubernetes folder

It does not contain code changes.

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| [before screenshot] | [after screenshot] |

## Testing

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->

**New environment variables**:

none

**New dependencies**:

cockroachdb

**New dev dependencies**:

skaffold
