### PR TITLE
Fixed name validation

### DIFF
--- a/src/common/form/validation.ts
+++ b/src/common/form/validation.ts
@@ -57,6 +57,6 @@ setLocale({
 })
 
 export const phoneRegex = /^\+?\d+$/
-export const noNumbersRegex = /^[^\d!@#$%^&*()\\/'"_-]*$/gi
+export const noNumbersRegex = /^[^\d!@#$%^&*()\\/'"_]*$/gi
 export const phone = string().trim().matches(phoneRegex, customValidators.phone).min(10).max(25)
 export const name = string().trim().matches(noNumbersRegex, customValidators.name).min(2).max(50)


### PR DESCRIPTION
Removed '-' from noNumbersRegex in order for the symbol to be allowed in Name and Last name text fields.

Screenshot:
![image](https://user-images.githubusercontent.com/14351733/110977501-e9f74300-836a-11eb-94ee-50adc2bd604a.png)
