### PR TITLE
Removed horizontal scrolling on homepage on mobile devices

### DIFF
--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -30,6 +30,9 @@ const useStyles = makeStyles((theme) =>
       textShadow: '0px 2px 3px #000',
       fontWeight: 600,
       marginBottom: theme.spacing(1),
+      [theme.breakpoints.down('xs')]: {
+        fontSize: theme.typography.pxToRem(45),
+      },
     },
     subTitle: {
       marginTop: theme.spacing(3),


### PR DESCRIPTION
Removed horizontal scrolling on homepage on mobile devices. 
The issue was caused by the larger font-size of the page title. Now it is 45px for mobile devices (under 600px):

![image](https://user-images.githubusercontent.com/14351733/111225171-22578500-85e8-11eb-9eb1-a62a3fd032c4.png)
