### PR TITLE
Submitting the support form through the newsletter dialog

### DIFF
--- a/src/components/support-form/SupportForm.tsx
+++ b/src/components/support-form/SupportForm.tsx
@@ -148,7 +148,7 @@ const NewsletterDialog = ({ isOpen, handleConfirm, handleCancel }: NewsletterDia
 export default function SupportForm() {
   const { t } = useTranslation()
   const classes = useStyles()
-  const formRef = useRef<FormikProps<SupportFormData>>() as RefObject<FormikProps<SupportFormData>>
+  const formRef = useRef<FormikProps<SupportFormData>>(null)
   const form = formRef?.current
   const [loading, setLoading] = useState(false)
   const [maxStep, setMaxStep] = useState<Steps>(Steps.ROLES)

--- a/src/components/support-form/SupportForm.tsx
+++ b/src/components/support-form/SupportForm.tsx
@@ -1,6 +1,6 @@
-import { FormikHelpers } from 'formik'
+import { FormikContextType, FormikFormProps, FormikHelpers } from 'formik'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef, ElementRef, MutableRefObject } from 'react'
 import { makeStyles, Theme, createStyles, withStyles } from '@material-ui/core/styles'
 import { Stepper, Step, StepLabel, StepConnector, Hidden, Grid } from '@material-ui/core'
 
@@ -148,6 +148,8 @@ const NewsletterDialog = ({ isOpen, handleConfirm, handleCancel }: NewsletterDia
 export default function SupportForm() {
   const { t } = useTranslation()
   const classes = useStyles()
+  const formRef = useRef<FormikHelpers<SupportFormData>>()
+  const form = formRef.current
   const [loading, setLoading] = useState(false)
   const [maxStep, setMaxStep] = useState<Steps>(Steps.ROLES)
   const [activeStep, setActiveStep] = useState<Steps>(Steps.ROLES)
@@ -167,12 +169,14 @@ export default function SupportForm() {
   const handleNewsletterDialogCancel = () => {
     setNewsletterDialogOpened(true)
     setNewsletterDialogOpen(false)
+    form?.submitForm()
   }
 
   const handleNewsletterDialogConfirm = () => {
     setNewsletterDialogOpened(true)
     setNewsletterDialogOpen(false)
-    setActiveStep((prevActiveStep) => prevActiveStep + 1)
+    form?.setFieldValue('newsletter', true)
+    form?.submitForm()
   }
 
   const handleBack = () => {
@@ -195,7 +199,6 @@ export default function SupportForm() {
       }
       setActiveStep((prevActiveStep) => prevActiveStep + 1)
       setFailedStep(Steps.NONE)
-      console.log(values)
       try {
         setLoading(true)
         const { person, newsletter, ...support_data } = values
@@ -310,7 +313,8 @@ export default function SupportForm() {
     <GenericForm<SupportFormData>
       onSubmit={handleSubmit}
       initialValues={initialValues}
-      validationSchema={validationSchema[activeStep]}>
+      validationSchema={validationSchema[activeStep]}
+      innerRef={formRef}>
       <Hidden smDown>
         <Stepper
           alternativeLabel

--- a/src/components/support-form/SupportForm.tsx
+++ b/src/components/support-form/SupportForm.tsx
@@ -1,6 +1,6 @@
-import { FormikContextType, FormikFormProps, FormikHelpers } from 'formik'
+import { FormikHelpers, FormikProps } from 'formik'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState, useRef, ElementRef, MutableRefObject } from 'react'
+import React, { useEffect, useState, useRef, RefObject } from 'react'
 import { makeStyles, Theme, createStyles, withStyles } from '@material-ui/core/styles'
 import { Stepper, Step, StepLabel, StepConnector, Hidden, Grid } from '@material-ui/core'
 
@@ -148,8 +148,8 @@ const NewsletterDialog = ({ isOpen, handleConfirm, handleCancel }: NewsletterDia
 export default function SupportForm() {
   const { t } = useTranslation()
   const classes = useStyles()
-  const formRef = useRef<FormikHelpers<SupportFormData>>()
-  const form = formRef.current
+  const formRef = useRef<FormikProps<SupportFormData>>() as RefObject<FormikProps<SupportFormData>>
+  const form = formRef?.current
   const [loading, setLoading] = useState(false)
   const [maxStep, setMaxStep] = useState<Steps>(Steps.ROLES)
   const [activeStep, setActiveStep] = useState<Steps>(Steps.ROLES)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

<!--- Why is this change required? -->
To be able to submit the form immediately after you either confirm or cancel the popup dialog.
<!--- If it fixes an open issue, please link to the issue here. -->
#159
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->
<!--- What problem are you trying to solve? -->
Previously when clicking the dialog buttons only the steps were advancing and no request was sent
<!--- How did you solve the problem? -->
Added a reference to the form with useRef() and used it to submit the form through the handleNewsletterDialogCancel/Confirm methods. There is a newer way to access the form through useFormikContext() hook, but that only works if the component you are accessing the hook from is a child of <Formik /> which the <SupportForm /> is not so I did it the old school way with innerRef.
<!--- Provide link to ora.pm task if any -->

## Screenshots:
| Before              | After              |
| No request was sent | A request is now sent to the backend |
|https://user-images.githubusercontent.com/893608/114022480-7d446b00-987a-11eb-87b9-7df3369d06e8.mp4 | ![image](https://user-images.githubusercontent.com/61479393/114089880-61af8380-98bf-11eb-8ff6-4d35fc3c9524.png)
 |


## Testing

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
Tested it both without checking the box and clicking confirm and cancel. And with a checked box previously and all request were sent correctly. 
Checked Box - newsletter:true 
Confirm - newsletter:true 
Cancel - newsletter:false 
<!--- Include links to the related pages -->
/support (last step)
<!--- Include details of your testing environment -->
Local Dev Environment
<!--- Impact of your change to other areas of the code -->

**New environment variables**:

- `env var` : env var details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
