### PR TITLE
Reduced about us button padding

### DIFF
--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme) =>
       color: theme.palette.common.white,
       border: `2px solid ${theme.palette.primary.main}`,
       borderRadius: theme.spacing(3),
-      padding: theme.spacing(1.5, 5),
+      padding: theme.spacing(1.5, 4),
       fontWeight: 500,
       fontSize: theme.typography.pxToRem(15),
       width: theme.spacing(27),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

<!--- Why is this change required? -->
Because the button was looking way bigger with the text on two lines and it didn't match the design
<!--- If it fixes an open issue, please link to the issue here. -->
#160 
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->
![image](https://user-images.githubusercontent.com/61479393/114092865-0da69e00-98c3-11eb-9782-4c243f3f22ff.png)
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
Changed the padding from theme.spacing(5) to theme.spacing(4) so that the text doesn't wrap now, but if more text is added to the button at a later moment it might still happen.
<!--- Provide link to ora.pm task if any -->

## Screenshots:

| Before              | After              |
| Text was wrapping | Text is on one line now |
|![image](https://user-images.githubusercontent.com/61479393/114092457-97a23700-98c2-11eb-888e-94ed7ab4c2da.png)) | ![image](https://user-images.githubusercontent.com/61479393/114092565-b43e6f00-98c2-11eb-9aa5-524a6324eaba.png)
 |
## Testing

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
Tested it on all resolutions and  it doesn't break anywhere.
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->
