### PR TITLE
🐛 Fix failing frontend docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ ARG NODE_ENV=production
 ENV PATH=/app/node_modules/.bin:$PATH \
   NODE_ENV="$NODE_ENV"
 COPY package.json yarn.lock /app/
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl g++ make python
 EXPOSE 3040
 
 # Build target dependencies #


### PR DESCRIPTION
Fixes #233

Added `g++`, `make` and `python` to the `frontend` image to fix the failing Docker build.