### PR TITLE
🐛 Fix failing campaigns docker build on Apple M1

### DIFF
--- a/backend/module-campaigns/Dockerfile
+++ b/backend/module-campaigns/Dockerfile
@@ -6,6 +6,13 @@ EXPOSE 5001
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends --assume-yes \
+      protobuf-compiler-grpc
+
+ENV PROTOBUF_PROTOC=/usr/bin/protoc
+
 COPY module-campaigns/src/ module-campaigns/src/
 COPY protos/ protos/
 


### PR DESCRIPTION
Fixes #237

It seems that the Apple M1 + Docker + dotnet + gRPC combination is problematic. The issue is described into details here:
https://danielstoyanoff.medium.com/apple-silicon-docker-dotnet-grpc-is-that-compatible-8a05f1a71d89

Long story short - nuget tries to use arm64 `protoc` which causes segmentation fault on M1. The workaround is to install `protoc` manually inside of the container and use that instead of the one provided by nuget.