### PR TITLE
Windows compatibility.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 ## General ##
 #############
 
+COMPOSE_PATH_SEPARATOR=":"
 COMPOSE_PROJECT_NAME=podkrepi
 COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ cd frontend
 
 # Symlink dev environment
 ln -s .env.example .env
+
+# Symlink dev environment on Windows
+mklink .env .env.example
 ```
 
 ## Development


### PR DESCRIPTION

- [x] **New environment variables for development**

- `COMPOSE_PATH_SEPARATOR` :   Customize path separator. COMPOSE_FILE supports multiple Compose files separated by a path separator ( on Linux and macOS the path separator is :, on Windows it is ; ). If set to ":" Windows based devs can compose without additional configs.

 
- [x] **Add Symlink  command for Windows**
