### PR TITLE
Rename .env files according to #204

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,40 +1,41 @@
 ## General ##
 #############
 
-COMPOSE_PROJECT_NAME=podkrepi-dev
-COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml
+COMPOSE_PATH_SEPARATOR=":"
+COMPOSE_PROJECT_NAME=podkrepi
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 
-WEB_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/web
-API_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/api
-FLYWAY_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/flyway
-CAMPAIGN_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/campaigns
+WEB_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/web
+API_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/api
+FLYWAY_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/flyway
+CAMPAIGN_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/campaign
 
-DEPLOY_TAG=
+DEPLOY_TAG=local
 
-# development, nightly, staging, production
-APP_ENV=nightly
+# development, staging, production
+APP_ENV=development
 # development, production
-NODE_ENV=production
+NODE_ENV=development
 # development, production
-TARGET_ENV=production
+TARGET_ENV=development
 
 ## API ##
 #########
 
-API_URL=https://api-dev1.podkrepi.bg
+API_URL=http://api.podkrepi.localhost
 REST_API_PORT=5000
 
 ## GraphQL ##
 #############
 
-GRAPHQL_URL=https://graph-dev1.podkrepi.bg
+GRAPHQL_URL=http://localhost:5050
 
 ## APP ##
 #########
 
-APP_URL=https://dev1.podkrepi.bg
+APP_URL=http://localhost:3040
 APP_PORT=3040
-NEXTAUTH_URL=https://dev1.podkrepi.bg
+NEXTAUTH_URL=http://localhost:3040
 JWT_SECRET=!Change__Me!
 
 # Sentry.io
@@ -42,12 +43,15 @@ SENTRY_DSN=https://e25f62860a394934878c2e21306a6b66@o540074.ingest.sentry.io/565
 SENTRY_ORG=podkrepibg
 SENTRY_PROJECT=app
 SENTRY_AUTH_TOKEN=
+SENTRY_SERVER_ROOT_DIR=/app
 
 ## GRPC Services ##
 ###################
 
 ACCOUNT_GRPC_URL=localhost:4040
+ACCOUNT_GRPC_PORT=4040
 CAMPAIGN_GRPC_URL=localhost:4060
+CAMPAIGN_GRPC_PORT=4060
 
 ## Database ##
 ##############
@@ -58,7 +62,8 @@ DB_PASS=
 DB_PORT=26257
 DB_NAME=app
 
-SSL_MODE=disable # disable, verify-ca
+# disable, verify-ca
+SSL_MODE=disable
 SSL_CA=/certs/ca.crt
 SSL_KEY=/certs/client.dp_user.crt
 SSL_CERT=/certs/client.dp_user.key
@@ -69,8 +74,8 @@ SSL_CERT=/certs/client.dp_user.key
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 
-## Prod Environment ##
-######################
+## Supabase ##
+##############
 
-FRONTEND_IPV4_ADDRESS=172.14.0.41
-API_IPV4_ADDRESS=172.14.0.42
+NEXT_PUBLIC_SUPABASE_URL=https://hercxgkjqqdokhofghnx.supabase.co
+NEXT_PUBLIC_SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYyMjYyNDMxMiwiZXhwIjoxOTM4MjAwMzEyfQ.GTwFefSWreDgYKcpJpTT0QBep1IG-v_28-p8Xb3uQB0

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,76 @@
+## General ##
+#############
+
+COMPOSE_PROJECT_NAME=podkrepi-dev
+COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml
+
+WEB_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/web
+API_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/api
+FLYWAY_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/flyway
+CAMPAIGN_DEPLOY_IMAGE=ghcr.io/daritelska-platforma/frontend/nightly/campaigns
+
+DEPLOY_TAG=
+
+# development, nightly, staging, production
+APP_ENV=nightly
+# development, production
+NODE_ENV=production
+# development, production
+TARGET_ENV=production
+
+## API ##
+#########
+
+API_URL=https://api-dev1.podkrepi.bg
+REST_API_PORT=5000
+
+## GraphQL ##
+#############
+
+GRAPHQL_URL=https://graph-dev1.podkrepi.bg
+
+## APP ##
+#########
+
+APP_URL=https://dev1.podkrepi.bg
+APP_PORT=3040
+NEXTAUTH_URL=https://dev1.podkrepi.bg
+JWT_SECRET=!Change__Me!
+
+# Sentry.io
+SENTRY_DSN=https://e25f62860a394934878c2e21306a6b66@o540074.ingest.sentry.io/5657969
+SENTRY_ORG=podkrepibg
+SENTRY_PROJECT=app
+SENTRY_AUTH_TOKEN=
+
+## GRPC Services ##
+###################
+
+ACCOUNT_GRPC_URL=localhost:4040
+CAMPAIGN_GRPC_URL=localhost:4060
+
+## Database ##
+##############
+
+DB_HOST=roach-lb
+DB_USER=root
+DB_PASS=
+DB_PORT=26257
+DB_NAME=app
+
+SSL_MODE=disable # disable, verify-ca
+SSL_CA=/certs/ca.crt
+SSL_KEY=/certs/client.dp_user.crt
+SSL_CERT=/certs/client.dp_user.key
+
+## Discord ##
+#############
+
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+## Prod Environment ##
+######################
+
+FRONTEND_IPV4_ADDRESS=172.14.0.41
+API_IPV4_ADDRESS=172.14.0.42

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -120,7 +120,7 @@ jobs:
         id: dotenv
         uses: falti/dotenv-action@v0.2.5
         with:
-          path: .env.dev
+          path: .env.staging
       - name: Start Deployment
         uses: TapTap21/docker-remote-deployment-action@v1.1
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ git clone git@github.com:daritelska-platforma/frontend.git
 cd frontend
 
 # Symlink dev environment
-ln -s .env.example .env
+ln -s .env.dev .env
 
 # Install dependencies
 yarn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ git clone git@github.com:daritelska-platforma/frontend.git
 cd frontend
 
 # Symlink dev environment
-ln -s .env.dev .env
+ln -hfs .env.dev .env
 
 # Install dependencies
 yarn

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ git clone git@github.com:daritelska-platforma/frontend.git
 cd frontend
 
 # Symlink dev environment
-ln -s .env.example .env
+ln -s .env.dev .env
 
 # Symlink dev environment on Windows
-mklink .env .env.example
+mklink .env .env.dev
 ```
 
 ## Development

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -63,8 +63,8 @@ skaffold dev --no-prune=false --cache-artifacts=false --no-prune-children=false 
 ## How to configure from ground zero
 
 ```shell
-docker-compose -f ./docker-compose.yml --env-file=.env.example config > docker-compose-resolved.tmp \
+docker-compose -f ./docker-compose.yml --env-file=.env.dev config > docker-compose-resolved.tmp \
   && skaffold init --compose-file docker-compose-resolved.tmp
 ```
 
-It's important not to include `docker-compose.dev.yml` as it generates local mounting volumes that have no effect over kubernetes cluster. By default dev yaml is included in `.env.example` within `COMPOSE_FILE` var.
+It's important not to include `docker-compose.dev.yml` as it generates local mounting volumes that have no effect over kubernetes cluster. By default dev yaml is included in `.env.dev` within `COMPOSE_FILE` var.


### PR DESCRIPTION
Renamed .env.example to .env.dev and .env.dev to .env.staging as per #204  
Guidelines and config files are updated accordingly.

## Motivation and context
The fix was needed to clear the confusion which .env. file is used for what purpose.
.dev is for local development
.staging is used for nightly deployments to dev1.podkrepi.bg

## Testing
changed symling to .env.dev and started the site with docker-compose - works as before